### PR TITLE
Fixed issue to allow profiles to be specified

### DIFF
--- a/tasks/exec_inspec/exec_inspec.ts
+++ b/tasks/exec_inspec/exec_inspec.ts
@@ -64,7 +64,7 @@ async function run() {
                 }
 
                 // set the command and the arguments to run
-                command_args = sprintf("exec . %s %s", inspec_arguments, test_output_args);
+                command_args = sprintf("exec %s %s", inspec_arguments, test_output_args);
 
                 tl.debug(sprintf("InSpec Command [%s]: %s %s", inspec_profile_path, command, command_args));
 

--- a/tasks/exec_inspec/task.json
+++ b/tasks/exec_inspec/task.json
@@ -32,9 +32,9 @@
             "name": "inspecArguments",
             "type": "string",
             "label": "InSpec Arguments",
-            "defaultValue": "",
+            "defaultValue": ".",
             "required": false,
-            "helpMarkDown": "Additional arguments that should be passed to InSpec, e.g. a target"
+            "helpMarkDown": "Arguments that should be passed to `inspec exec`. By default this is all profiles in the directory."
         },
         {
             "name": "inspecResultsFile",


### PR DESCRIPTION
The problem here was that every argument added to the task parameters was appended to the default command of `inspec exec .`, which meant that any profile specified would be added to that command string.

Now the parameters have a default value of `.` so that it can be overridden as requited.

Fixes #36

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>