### PR TITLE
Correctly error build on InSpec error code

### DIFF
--- a/tasks/exec_inspec/exec_inspec.ts
+++ b/tasks/exec_inspec/exec_inspec.ts
@@ -100,7 +100,7 @@ async function run() {
                         let fail_message = "InSpec tests failed. Please review errors and try again.";
                         tl.setResult(tl.TaskResult.Failed, fail_message);
 
-                    } else if (command_result.code === 100 || command_result.code === 101) {
+                    } else if (command_result.code === 101) {
 
                         // create message
                         let warn_message = "";

--- a/tasks/exec_inspec/exec_inspec.ts
+++ b/tasks/exec_inspec/exec_inspec.ts
@@ -93,7 +93,6 @@ async function run() {
                     // fail the build if the values do not match the above
                     // or produce warnings if 100 or 101
                     if (command_result.code !== 0 &&
-                        command_result.code !== 100 &&
                         command_result.code !== 101) {
 
                         console.log(command_result.stderr);
@@ -106,9 +105,6 @@ async function run() {
                         // create message
                         let warn_message = "";
                         switch (command_result.code) {
-                            case 100:
-                                warn_message = "Execution was successful but some tests have failed";
-                                break;
                             case 101:
                                 warn_message = "Execution was successful but some tests were skipped";
                                 break;


### PR DESCRIPTION
InSpec emits several different error codes:

0 - run was completely successful
100 - run was successful but some tests failed
101 - run was successful but some tests were skipped

This change modifies the task so that 100 causes the task to fail rather than just warn. 101 will still warn.